### PR TITLE
Allow pronto checks against specific commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gem 'pronto-scss'
 
 ## Usage
 
-Run Files through Pronto.
+Pronto runs the checks on a diff between the current HEAD and the provided commit-ish (default is master).
 Results are passed out as a table in markdown.
 
 
@@ -34,18 +34,17 @@ Specifying custom config file.
 pronto.lint
 ```
 
-Lint specific files in a folder, when they change
+Run checks on a diff between the current HEAD and a specified commit
 ```ruby
-public_files = (modified_files + added_files).select { |path| path.include?("/public/") }
-pronto.lint public_files
+pronto.lint("e757913")
 ```
 
 #### Methods
 
 
-`lint(files: String)`
+`lint(commit: String)`
 
- Runs files through Pronto. Generates a `markdown` list of warnings.
+ Runs checks on a diff between the current HEAD and the provided commit-ish (default is master). Generates a `markdown` list of warnings.
 
 
 

--- a/lib/danger_pronto/gem_version.rb
+++ b/lib/danger_pronto/gem_version.rb
@@ -1,3 +1,3 @@
 module Pronto
-  VERSION = "0.2.1".freeze
+  VERSION = "0.3.0".freeze
 end

--- a/lib/danger_pronto/plugin.rb
+++ b/lib/danger_pronto/plugin.rb
@@ -14,8 +14,8 @@ module Danger
   class DangerPronto < Plugin
 
     # Runs files through Pronto. Generates a `markdown` list of warnings.
-    def lint(files = nil)
-      files = pronto
+    def lint(commit = nil)
+      files = pronto(commit)
       return if files.empty?
 
       markdown offenses_message(files)
@@ -24,9 +24,12 @@ module Danger
     private
 
     # Executes pronto command
+    # @param commit [String] hash/branch/tag
     # @return [Hash] Converted hash from pronto json output
-    def pronto
-      pronto_output = `#{'bundle exec ' if File.exists?('Gemfile')}pronto run -f json -c origin/master`
+    def pronto(specified_commit = nil)
+      commit = "origin/master"
+      commit = specified_commit if specified_commit.present?
+      pronto_output = `#{'bundle exec ' if File.exists?('Gemfile')}pronto run -f json -c #{commit}`
       JSON.parse(pronto_output)
     end
 


### PR DESCRIPTION
This defaults pronto running against `origin/master`. You can now specify a specific commit.